### PR TITLE
Fix ItemFrame Invisible Rotation Issues

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -81,7 +81,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 	}
 
 	@Override
-	public void onEnable(){
+	public void onEnable(){ //FIX for Complexity will be done in 1.17.1-31
 		scoreboard = this.getServer().getScoreboardManager().getMainScoreboard();
 		registerScoreboards();
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -73,7 +73,6 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 	public Scoreboard scoreboard;
 	public Team team;
 
-	private static ArmorStandEditorPlugin plugin;
 
 	private static final int PLUGIN_ID = 12668;
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -381,12 +381,8 @@ public class PlayerEditor {
 			itemFrame.setFixed(!itemFrame.isFixed());
 			itemFrame.setItem(AIR_BLOCK);
 			itemFrame.setFixed(!itemFrame.isFixed());
-		} else if(itemCurrentlyInFrame.getType() != Material.AIR && player.getInventory().getItemInMainHand().getType() == Material.FLINT){
-			ItemStack BLOCK_IN_FRAME = new ItemStack(itemCurrentlyInFrame.getType(), 1);
-			itemFrame.setFixed(!itemFrame.isFixed());
-			itemFrame.setItem(BLOCK_IN_FRAME);
-			itemFrame.setFixed(!itemFrame.isFixed());
 		}
+
 		itemFrame.setVisible(!itemFrame.isVisible());
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -34,8 +34,12 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -374,7 +378,9 @@ public class PlayerEditor {
 
 		//TODO: Wolfst0rm/ArmorStandEditor-Issues#3 - ItemFrame Invisible Rotate Issue
 		itemFrame.setVisible(!itemFrame.isVisible());
+
 	}
+
 
 	void toggleSize(ArmorStand armorStand) {
 		armorStand.setSmall(!armorStand.isSmall());

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -375,7 +375,6 @@ public class PlayerEditor {
 
 	}
 
-
 	void toggleSize(ArmorStand armorStand) {
 		armorStand.setSmall(!armorStand.isSmall());
 	}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -369,7 +369,13 @@ public class PlayerEditor {
 	}
 
 	void toggleItemFrameVisible(ItemFrame itemFrame) {//Should run checKItemFrameRotate before doing any of this
-		if (!getPlayer().hasPermission("asedit.invisible")) return; //Changed to Invisible, better that visibility is all under same permission node
+		Player player = getPlayer();
+		if (!player.hasPermission("asedit.invisible")) return; //Changed to Invisible, better that visibility is all under same permission node
+
+		if(player.getInventory().getItemInMainHand().getType() == Material.FLINT){
+			//Holding Flint and Toggle Enabled
+			//TODO: Cancel Flint going in
+		}
 
 		itemFrame.setVisible(!itemFrame.isVisible());
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -36,7 +36,9 @@ import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -370,15 +372,16 @@ public class PlayerEditor {
 
 	void toggleItemFrameVisible(ItemFrame itemFrame) {//Should run checKItemFrameRotate before doing any of this
 		Player player = getPlayer();
+		ItemStack itemCurrentlyInFrame = itemFrame.getItem();
 		if (!player.hasPermission("asedit.invisible")) return; //Changed to Invisible, better that visibility is all under same permission node
 
 		if(player.getInventory().getItemInMainHand().getType() == Material.FLINT){
 			//Holding Flint and Toggle Enabled
-			//TODO: Cancel Flint going in
+			itemFrame.setFixed(!itemFrame.isFixed());
+			itemFrame.setItem(itemCurrentlyInFrame);
+			itemFrame.setFixed(!itemFrame.isFixed());
 		}
-
 		itemFrame.setVisible(!itemFrame.isVisible());
-
 	}
 
 	void toggleSize(ArmorStand armorStand) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -372,13 +372,19 @@ public class PlayerEditor {
 
 	void toggleItemFrameVisible(ItemFrame itemFrame) {//Should run checKItemFrameRotate before doing any of this
 		Player player = getPlayer();
-		ItemStack itemCurrentlyInFrame = itemFrame.getItem();
+		ItemStack itemCurrentlyInFrame = itemFrame.getItem(); //get the Item that is currently in the ItemFrame
 		if (!player.hasPermission("asedit.invisible")) return; //Changed to Invisible, better that visibility is all under same permission node
 
-		if(player.getInventory().getItemInMainHand().getType() == Material.FLINT){
-			//Holding Flint and Toggle Enabled
+		if(itemCurrentlyInFrame.getType() == Material.AIR && player.getInventory().getItemInMainHand().getType() == Material.FLINT){
+			//Player is HOLDING Flint and ItemFrame is Empty (Common Scenario)
+			ItemStack AIR_BLOCK = new ItemStack(Material.AIR , 1);
 			itemFrame.setFixed(!itemFrame.isFixed());
-			itemFrame.setItem(itemCurrentlyInFrame);
+			itemFrame.setItem(AIR_BLOCK);
+			itemFrame.setFixed(!itemFrame.isFixed());
+		} else if(itemCurrentlyInFrame.getType() != Material.AIR && player.getInventory().getItemInMainHand().getType() == Material.FLINT){
+			ItemStack BLOCK_IN_FRAME = new ItemStack(itemCurrentlyInFrame.getType(), 1);
+			itemFrame.setFixed(!itemFrame.isFixed());
+			itemFrame.setItem(BLOCK_IN_FRAME);
 			itemFrame.setFixed(!itemFrame.isFixed());
 		}
 		itemFrame.setVisible(!itemFrame.isVisible());

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -382,7 +382,7 @@ public class PlayerEditor {
 		itemFrame.setVisible(!itemFrame.isVisible());
 	}
 
-	//TODO: ToggleItemFrameFixed Status - For v1.17.1-31
+	//TODO: ToggleItemFrameFixed Status - For v1.17.1-31 or see Wolfst0rm/ArmorStandEditor-Issues#9
 
 	void toggleSize(ArmorStand armorStand) {
 		armorStand.setSmall(!armorStand.isSmall());

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -183,7 +183,7 @@ public class PlayerEditor {
 			case RESET:
 				itemFrame.setVisible(true);
 			case NONE:
-				sendMessage("nomode", null);
+				sendMessage("nomodeif", null);
 				break;
 		}
 	}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -36,8 +36,8 @@ import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -48,7 +48,7 @@ import org.bukkit.util.EulerAngle;
 public class PlayerEditor {
 	public ArmorStandEditorPlugin plugin;
 	Team team;
-	private UUID uuid;
+	private final UUID uuid;
 	UUID armorStandID;
 	EditMode eMode;
 	AdjustmentMode adjMode;
@@ -68,7 +68,6 @@ public class PlayerEditor {
 	int frameTargetIndex = 0;
 	EquipmentMenu equipMenu;
 	long lastCancelled = 0;
-	private boolean state;
 
 	public PlayerEditor(UUID uuid, ArmorStandEditorPlugin plugin) {
 		this.uuid = uuid;
@@ -351,8 +350,6 @@ public class PlayerEditor {
 	private void toggleGravity(ArmorStand armorStand) { //Fix for Wolfst0rm/ArmorStandEditor-Issues#6: Translation of On/Off Keys are broken
 
 		armorStand.setGravity(!armorStand.hasGravity());
-		//String state = armorStand.hasGravity() ? "on" : "off";
-		//sendMessage("setgravity", state);
 		sendMessage("setgravity", String.valueOf(armorStand.hasGravity()));
 
 	}
@@ -377,14 +374,15 @@ public class PlayerEditor {
 
 		if(itemCurrentlyInFrame.getType() == Material.AIR && player.getInventory().getItemInMainHand().getType() == Material.FLINT){
 			//Player is HOLDING Flint and ItemFrame is Empty (Common Scenario)
-			ItemStack AIR_BLOCK = new ItemStack(Material.AIR , 1);
 			itemFrame.setFixed(!itemFrame.isFixed());
-			itemFrame.setItem(AIR_BLOCK);
+			itemFrame.setItem(itemCurrentlyInFrame); //So in this case we set it to be air
 			itemFrame.setFixed(!itemFrame.isFixed());
 		}
 
 		itemFrame.setVisible(!itemFrame.isVisible());
 	}
+
+	//TODO: ToggleItemFrameFixed Status - For v1.17.1-31
 
 	void toggleSize(ArmorStand armorStand) {
 		armorStand.setSmall(!armorStand.isSmall());

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -34,16 +34,12 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scoreboard.Scoreboard;
+
 import org.bukkit.scoreboard.Team;
 import org.bukkit.util.EulerAngle;
 
@@ -372,11 +368,9 @@ public class PlayerEditor {
 		armorStand.setVisible(!armorStand.isVisible());
 	}
 
-	void toggleItemFrameVisible(ItemFrame itemFrame) {
+	void toggleItemFrameVisible(ItemFrame itemFrame) {//Should run checKItemFrameRotate before doing any of this
 		if (!getPlayer().hasPermission("asedit.invisible")) return; //Changed to Invisible, better that visibility is all under same permission node
-		//Potential for OnInteractEvent for ItemFrame to Disable Interaction
 
-		//TODO: Wolfst0rm/ArmorStandEditor-Issues#3 - ItemFrame Invisible Rotate Issue
 		itemFrame.setVisible(!itemFrame.isVisible());
 
 	}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -55,7 +55,7 @@ public class PlayerEditorManager implements Listener {
 	private  TickCounter counter;
 	private ArrayList<ArmorStand> as = null;
 	private ArrayList<ItemFrame> itemF = null;
-	private ArrayList<ItemFrame> itemFrameRotated = null;
+	private ArrayList<ItemFrame> itemFrameLookedAt = null;
 
 
 	PlayerEditorManager( ArmorStandEditorPlugin plugin) {
@@ -410,41 +410,28 @@ public class PlayerEditorManager implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	void checkItemFrameRotate(PlayerInteractEntityEvent event){
+	void checkItemFrameRotate(PlayerInteractEntityEvent event) {
 		Player player = event.getPlayer();
-		if(event.getRightClicked() instanceof ItemFrame){
-			boolean itemFrameInvis = ((ItemFrame) event.getRightClicked()).isVisible();
-			ItemStack itemFrameContainsItem = ((ItemFrame) event.getRightClicked()).getItem();
+		if (event.getRightClicked() instanceof ItemFrame) {
+			ItemFrame itemF = ((ItemFrame) event.getRightClicked());
+			boolean itemFrameInvis = itemF.isVisible();
 
-			if(itemFrameInvis){
+			if (!itemFrameInvis) {  //If Visible then we do nothing and do not cancel the event - So if we want to set it Invis we can
 
-				if (itemFrameContainsItem != null) {
+				event.setCancelled(false);
 
-					//Firstly, Ensure Flint doesnt go into the frame.
-					//CASE:  If the itemframe does not contain an item, the flint item will go into it.
-					if (plugin.isEditTool(player.getInventory().getItemInMainHand())) {
-						if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) {
-							event.setCancelled(true);
-						}
-					}
-				} else{
-					if (plugin.isEditTool(player.getInventory().getItemInMainHand())) {
-						if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) {
-							event.setCancelled(true);
-						}
-					}
+			} else { //ItemFrame is Invisible - Regardless of if it has an item or not
+
+				//Dont Bother looking at it if not holding flint
+				if (player.getInventory().getItemInMainHand().getType() != Material.FLINT)
+					event.setCancelled(false);
+
+				//If we are HOLDING Flint and when we rightclick the ItemFrame
+				if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)
+						&& event.getRightClicked().getType().equals(itemF.getType())) {
+					event.setCancelled(true);
 				}
-				//Next: Only if the item is not flint.
-				// When making the itemframe invisible, and the itemframe already contains an item;
-				// using right click to make the itemframe invisible, it will rotate. (With left click it will not rotate)
-				itemFrameRotated = getFrameTargets(player); //Get all the Frames near the player
-				if(itemFrameRotated.isEmpty()) return; //Sanity Check
-				for (ItemFrame itemFrame : itemFrameRotated) { // Loop over the ItemFrames
-					if (!itemFrame.isVisible()) continue; //Only apply if the ItemFrame is Invisible. Skip if not.
-					if(player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) { //If Item is EditTool
-						event.setCancelled(true); // Cancel the Event.
-					}
-				}
+
 			}
 		}
 	}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -415,6 +415,7 @@ public class PlayerEditorManager implements Listener {
 		final ItemFrame itemFrame = (ItemFrame) clicked;
 		final ItemStack itemInFrame = itemFrame.getItem();
 		final Player currentPlayer = event.getPlayer();
+		final Rotation itemFrameRot = itemFrame.getRotation();
 		final PlayerInventory currentInv = currentPlayer.getInventory();
 		final Material itemInHand = currentInv.getItemInMainHand().getType();
 		final boolean isItemFrameVisible = itemFrame.isVisible();
@@ -426,7 +427,7 @@ public class PlayerEditorManager implements Listener {
 				//Firstly, Does ItemFrame contain an Item
 				//If so Keep the Current Rotation and get out ASAP
 				if(itemInFrame.getItemMeta() != null){
-					((ItemFrame) clicked).setRotation(itemFrame.getRotation());
+					((ItemFrame) clicked).setRotation(itemFrameRot);
 					return;
 				} else { //No Item
 					//Secondly, If there is no item within and Is the player Holding a Flint
@@ -442,7 +443,7 @@ public class PlayerEditorManager implements Listener {
 				if(itemInFrame.getItemMeta() != null){
 					//Firstly, Does ItemFrame contain an Item
 					//If so Keep the Current Rotation and get out ASAP
-					((ItemFrame) clicked).setRotation(itemFrame.getRotation());
+					((ItemFrame) clicked).setRotation(itemFrameRot);
 					event.setCancelled(true); //Cancel all Events
 					if (event.isCancelled()) return; //Get out once event has been canceled
 				}else {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -410,45 +410,39 @@ public class PlayerEditorManager implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	void checkItemFrameRotate(PlayerInteractAtEntityEvent event) {
+	void checkItemFrameRotate(PlayerInteractEntityEvent event) {
 		final Entity clicked = event.getRightClicked();
 		final ItemFrame itemFrame = (ItemFrame) clicked;
 		final ItemStack itemInFrame = itemFrame.getItem();
 		final Rotation currentRot = itemFrame.getRotation();
-		final PlayerInventory currentInv = event.getPlayer().getInventory();
+		final Player currentPlayer = event.getPlayer();
+		final PlayerInventory currentInv = currentPlayer.getInventory();
+		final Material itemInHand = currentInv.getItemInMainHand().getType();
 		final boolean isItemFrameVisible = itemFrame.isVisible();
 
-		if (clicked != null && clicked instanceof ItemFrame){
+		if (clicked != null && clicked instanceof ItemFrame){ //Only apply the below Logic to Entity ItemFrame
 
-			if(event.isCancelled()) return;
+			if(isItemFrameVisible){ //ItemFrame is Visible Check - Deal with it being Visible First
 
-			if(isItemFrameVisible == true){ //ItemFrame is Visible
-				//First Check: Does ItemFrame contain an Item
-				if(itemInFrame.getItemMeta() != null){ //We can get Item's MetaData and Cancel Rotate
-					itemFrame.setRotation(currentRot); // So Keep Current Rotation
+				//Firstly, Does ItemFrame contain an Item
+				//If so Keep the Current Rotation and get out ASAP
+				if(itemInFrame.getItemMeta() != null){
+					itemFrame.setRotation(currentRot);
 					return;
 				} else { //No Item
-					//Second Check: Is the player Holding a Flint
-					if(currentInv.getItemInMainHand().getType() == FLINT){ //Player is Holding Flint, attempt to block it from going in.
-						itemFrame.setRotation(currentRot); //Keep Current Rotation
-						event.setCancelled(true); //STop Flint from going in???
-						if(event.isCancelled()) return;
+					//Secondly, If there is no item within and Is the player Holding a Flint
+					//Assume that intention is to add Flint to the ItemFrame
+					if(itemInHand == FLINT){
+						event.setCancelled(true); //Cancel all Events
+						if(event.isCancelled()) return; //Get out once event has been canceled
 
 					} else{
-						return;
+						return; //BreakOut
 					}
 				}
-			} else{ //Item Frame is Invisible
-				if(itemInFrame.getItemMeta() == null && currentInv.getItemInMainHand().getType() == FLINT){ //Regardless we do not want FLINT in an ItemFrame\
-					itemFrame.setRotation(currentRot);
-					event.setCancelled(true);
-					if(event.isCancelled()) return;
-				}else{
-					return;
-				}
-			}
+			} 
 		} else{
-			return;
+			return; //Break Out as doesnt apply!
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -414,15 +414,26 @@ public class PlayerEditorManager implements Listener {
 		Player player = event.getPlayer();
 		if(event.getRightClicked() instanceof ItemFrame){
 			boolean itemFrameInvis = ((ItemFrame) event.getRightClicked()).isVisible();
-			if(itemFrameInvis) {
-				itemFrameRotated = getFrameTargets(player);
+
+			if(itemFrameInvis){
+
+				//Firstly, Ensure Flint doesnt go into the frame.
+				//CASE:  If the itemframe does not contain an item, the flint item will go into it.
+				if(plugin.isEditTool(player.getInventory().getItemInMainHand())){
+					if(player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)){
+						event.setCancelled(true);
+					}
+				}
+
+				//Next: Only if the item is not flint.
+				// When making the itemframe invisible, and the itemframe already contains an item;
+				// using right click to make the itemframe invisible, it will rotate. (With left click it will not rotate)
+				itemFrameRotated = getFrameTargets(player); //Get all the Frames near the player
 				if(itemFrameRotated.isEmpty()) return; //Sanity Check
-				if (!itemFrameRotated.isEmpty()) {
-					for (int i = 0; i < itemFrameRotated.size(); i++) {
-						if (!itemFrameRotated.get(i).isVisible()) continue; //Only apply if the ItemFrame is Invisible. Skip if not.
-						if (itemFrameRotated.get(i).getItem().getType() == Material.FLINT) {
-							event.setCancelled(true);
-						}
+				for (ItemFrame itemFrame : itemFrameRotated) { // Loop over the ItemFrames
+					if (!itemFrame.isVisible()) continue; //Only apply if the ItemFrame is Invisible. Skip if not.
+					if(player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) { //If Item is EditTool
+						event.setCancelled(true); // Cancel the Event.
 					}
 				}
 			}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -410,30 +410,42 @@ public class PlayerEditorManager implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	void checkItemFrameRotate(PlayerInteractEntityEvent event) {
-		Player player = event.getPlayer();
-		if (event.getRightClicked() instanceof ItemFrame) {
-			ItemFrame itemF = ((ItemFrame) event.getRightClicked());
-			boolean itemFrameInvis = itemF.isVisible();
+	void checkItemFrameRotate(PlayerInteractAtEntityEvent event) {
+		//So get ItemFrame RightClicked and the item contained within
+		ItemFrame itemFrameEntity = ((ItemFrame)event.getRightClicked());
+		ItemStack itemInFrame = itemFrameEntity.getItem();
 
-			if (!itemFrameInvis) {  //If Visible then we do nothing and do not cancel the event - So if we want to set it Invis we can
+		//Get Player doing the event - So we can track Inventory
+		Player playerInv = event.getPlayer();
 
-				event.setCancelled(false);
+		//Get Visibility Status
+		boolean itemFrameVisibility = itemFrameEntity.isVisible();
 
-			} else { //ItemFrame is Invisible - Regardless of if it has an item or not
+		if(itemFrameVisibility){ //If Visibile is TRUE
 
-				//Dont Bother looking at it if not holding flint
-				if (player.getInventory().getItemInMainHand().getType() != Material.FLINT)
-					event.setCancelled(false);
+			return; // DO NOTHING
 
-				//If we are HOLDING Flint and when we rightclick the ItemFrame
-				if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)
-						&& event.getRightClicked().getType().equals(itemF.getType())) {
+		} else { //If Inivisible
+
+			if (itemInFrame.getType() != null) { //Item Frame doesnt contain an item
+
+				if(playerInv.getInventory().getItemInMainHand().getType() == Material.FLINT){
+
 					event.setCancelled(true);
+
+				} else{
+
+					return;
+
 				}
+
+			} else { //Item in the ItemFrame
+
+				event.setCancelled(true); //Cancel the Rotation
+
 			}
-		} else{ // if if not then we dont do anything and cancel the event.
-			event.setCancelled(false);
+
+
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
+import static org.bukkit.Material.*;
+
 //Manages PlayerEditors and Player Events related to editing armorstands
 public class PlayerEditorManager implements Listener {
 	private  ArmorStandEditorPlugin plugin;
@@ -53,6 +55,7 @@ public class PlayerEditorManager implements Listener {
 	private  TickCounter counter;
 	private ArrayList<ArmorStand> as = null;
 	private ArrayList<ItemFrame> itemF = null;
+	private ArrayList<ItemFrame> itemFrameRotated = null;
 
 
 	PlayerEditorManager( ArmorStandEditorPlugin plugin) {
@@ -109,7 +112,7 @@ public class PlayerEditorManager implements Listener {
 
 
 			//Attempt rename
-			if (player.getInventory().getItemInMainHand().getType() == Material.NAME_TAG && player.hasPermission("asedit.rename")) {
+			if (player.getInventory().getItemInMainHand().getType() == NAME_TAG && player.hasPermission("asedit.rename")) {
 				ItemStack nameTag = player.getInventory().getItemInMainHand();
 				 String name;
 				if (nameTag.getItemMeta() != null && nameTag.getItemMeta().hasDisplayName()) {
@@ -129,7 +132,7 @@ public class PlayerEditorManager implements Listener {
 						if (nameTag.getAmount() > 1) {
 							nameTag.setAmount(nameTag.getAmount() - 1);
 						} else {
-							nameTag = new ItemStack(Material.AIR);
+							nameTag = new ItemStack(AIR);
 						}
 						player.getInventory().setItemInMainHand(nameTag);
 					}
@@ -148,20 +151,20 @@ public class PlayerEditorManager implements Listener {
 			if (!canEdit(player, itemFrame)) return;
 			if (plugin.isEditTool(player.getInventory().getItemInMainHand())) {
 				getPlayerEditor(player.getUniqueId()).cancelOpenMenu();
-				if (!itemFrame.getItem().getType().equals(Material.AIR)) {
+				if (!itemFrame.getItem().getType().equals(AIR)) {
 					event.setCancelled(true);
 				}
 				applyRightTool(player, itemFrame);
 				return;
 			}
 
-			if (player.getInventory().getItemInMainHand().getType().equals(Material.GLOW_INK_SAC) //attempt glowing
+			if (player.getInventory().getItemInMainHand().getType().equals(GLOW_INK_SAC) //attempt glowing
 					&& player.hasPermission("asedit.basic")
 					&& plugin.glowItemFrames && player.isSneaking()) {
 				ItemStack glowSacs = player.getInventory().getItemInMainHand();
 				ItemStack contents = null;
 				Rotation rotation = null;
-				if (itemFrame.getItem().getType() != Material.AIR) {
+				if (itemFrame.getItem().getType() != AIR) {
 					contents = itemFrame.getItem(); //save item
 					rotation = itemFrame.getRotation(); // save item rotation
 				}
@@ -171,7 +174,7 @@ public class PlayerEditorManager implements Listener {
 				if (player.getGameMode() != GameMode.CREATIVE) {
 					if (glowSacs.getAmount() > 1) {
 						glowSacs.setAmount(glowSacs.getAmount() - 1);
-					} else glowSacs = new ItemStack(Material.AIR);
+					} else glowSacs = new ItemStack(AIR);
 				}
 
 				itemFrame.remove();
@@ -241,7 +244,7 @@ public class PlayerEditorManager implements Listener {
 		return armorStands;
 	}
 
-	private ArrayList<ItemFrame> getFrameTargets(Player player) {
+	public ArrayList<ItemFrame> getFrameTargets(Player player) {
 		Location eyeLaser = player.getEyeLocation();
 		Vector direction = player.getLocation().getDirection();
 		ArrayList<ItemFrame> itemFrames = new ArrayList<>();
@@ -403,6 +406,24 @@ public class PlayerEditorManager implements Listener {
 		if (e.getInventory().getHolder() == equipmentHolder) {
 			 PlayerEditor pe = players.get(e.getPlayer().getUniqueId());
 			pe.equipMenu.equipArmorstand();
+		}
+	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	void checkItemFrameRotate(PlayerInteractEntityEvent event){
+		Player player = event.getPlayer();
+		if(event.getRightClicked() instanceof ItemFrame){
+			boolean itemFrameInvis = ((ItemFrame) event.getRightClicked()).isVisible();
+			if(itemFrameInvis) {
+				itemFrameRotated = getFrameTargets(player);
+				if (!itemFrameRotated.isEmpty()) {
+					for (int i = 0; i < itemFrameRotated.size(); i++) {
+						if (itemFrameRotated.get(i).getItem().getType() == Material.FLINT) {
+							event.setCancelled(true);
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -432,17 +432,24 @@ public class PlayerEditorManager implements Listener {
 				} else { //No Item
 					//Secondly, If there is no item within and Is the player Holding a Flint
 					//Assume that intention is to add Flint to the ItemFrame
-					if(itemInHand == FLINT){
+					if (itemInHand == FLINT) {
 						event.setCancelled(true); //Cancel all Events
-						if(event.isCancelled()) return; //Get out once event has been canceled
-
-					} else{
-						return; //BreakOut
+						if (event.isCancelled()) return; //Get out once event has been canceled
+					} else {
+						return;
 					}
 				}
-			} 
+			} else{
+				if(itemInFrame.getItemMeta() != null){
+					itemFrame.setRotation(currentRot);
+					event.setCancelled(true); //Cancel all Events
+					if (event.isCancelled()) return; //Get out once event has been canceled
+				} else{
+					return;
+				}
+			}
 		} else{
-			return; //Break Out as doesnt apply!
+			return;
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -414,7 +414,6 @@ public class PlayerEditorManager implements Listener {
 		final Entity clicked = event.getRightClicked();
 		final ItemFrame itemFrame = (ItemFrame) clicked;
 		final ItemStack itemInFrame = itemFrame.getItem();
-		final Rotation currentRot = itemFrame.getRotation();
 		final Player currentPlayer = event.getPlayer();
 		final PlayerInventory currentInv = currentPlayer.getInventory();
 		final Material itemInHand = currentInv.getItemInMainHand().getType();
@@ -427,7 +426,7 @@ public class PlayerEditorManager implements Listener {
 				//Firstly, Does ItemFrame contain an Item
 				//If so Keep the Current Rotation and get out ASAP
 				if(itemInFrame.getItemMeta() != null){
-					itemFrame.setRotation(currentRot);
+					((ItemFrame) clicked).setRotation(itemFrame.getRotation());
 					return;
 				} else { //No Item
 					//Secondly, If there is no item within and Is the player Holding a Flint
@@ -439,13 +438,15 @@ public class PlayerEditorManager implements Listener {
 						return;
 					}
 				}
-			} else{
+			} else{ //ItemFrame Invisible
 				if(itemInFrame.getItemMeta() != null){
-					itemFrame.setRotation(currentRot);
+					//Firstly, Does ItemFrame contain an Item
+					//If so Keep the Current Rotation and get out ASAP
+					((ItemFrame) clicked).setRotation(itemFrame.getRotation());
 					event.setCancelled(true); //Cancel all Events
 					if (event.isCancelled()) return; //Get out once event has been canceled
-				} else{
-					return;
+				}else {
+					return;//So we can toggle visiblity later
 				}
 			}
 		} else{

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -422,34 +422,31 @@ public class PlayerEditorManager implements Listener {
 
 		if (clicked != null && clicked instanceof ItemFrame){ //Only apply the below Logic to Entity ItemFrame
 
+			//Get out once event has been canceled
 			if(isItemFrameVisible){ //ItemFrame is Visible Check - Deal with it being Visible First
 
 				//Firstly, Does ItemFrame contain an Item
 				//If so Keep the Current Rotation and get out ASAP
+				//Get out once event has been canceled
 				if(itemInFrame.getItemMeta() != null){
 					((ItemFrame) clicked).setRotation(itemFrameRot);
-					return;
 				} else { //No Item
 					//Secondly, If there is no item within and Is the player Holding a Flint
 					//Assume that intention is to add Flint to the ItemFrame
 					if (itemInHand == FLINT) {
 						event.setCancelled(true); //Cancel all Events
-						if (event.isCancelled()) return; //Get out once event has been canceled
-					} else {
-						return;
 					}
 				}
 			} else{ //ItemFrame Invisible
+				//So we can toggle visiblity later
 				if(itemInFrame.getItemMeta() != null){
 					//Firstly, Does ItemFrame contain an Item
 					//If so Keep the Current Rotation and get out ASAP
 					((ItemFrame) clicked).setRotation(itemFrameRot);
 					event.setCancelled(true); //Cancel all Events
-					if (event.isCancelled()) return; //Get out once event has been canceled
-				}else {
-					return;//So we can toggle visiblity later
 				}
 			}
+			return;
 		} else{
 			return;
 		}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -414,17 +414,26 @@ public class PlayerEditorManager implements Listener {
 		Player player = event.getPlayer();
 		if(event.getRightClicked() instanceof ItemFrame){
 			boolean itemFrameInvis = ((ItemFrame) event.getRightClicked()).isVisible();
+			ItemStack itemFrameContainsItem = ((ItemFrame) event.getRightClicked()).getItem();
 
 			if(itemFrameInvis){
 
-				//Firstly, Ensure Flint doesnt go into the frame.
-				//CASE:  If the itemframe does not contain an item, the flint item will go into it.
-				if(plugin.isEditTool(player.getInventory().getItemInMainHand())){
-					if(player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)){
-						event.setCancelled(true);
+				if (itemFrameContainsItem != null) {
+
+					//Firstly, Ensure Flint doesnt go into the frame.
+					//CASE:  If the itemframe does not contain an item, the flint item will go into it.
+					if (plugin.isEditTool(player.getInventory().getItemInMainHand())) {
+						if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) {
+							event.setCancelled(true);
+						}
+					}
+				} else{
+					if (plugin.isEditTool(player.getInventory().getItemInMainHand())) {
+						if (player.getInventory().getItemInMainHand().getType().equals(Material.FLINT)) {
+							event.setCancelled(true);
+						}
 					}
 				}
-
 				//Next: Only if the item is not flint.
 				// When making the itemframe invisible, and the itemframe already contains an item;
 				// using right click to make the itemframe invisible, it will rotate. (With left click it will not rotate)

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -21,7 +21,6 @@ package io.github.rypofalem.armorstandeditor;
 
 import io.github.rypofalem.armorstandeditor.menu.ASEHolder;
 import org.bukkit.*;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.*;
 import org.bukkit.event.*;
@@ -32,7 +31,6 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 
@@ -45,18 +43,20 @@ import static org.bukkit.Material.*;
 
 //Manages PlayerEditors and Player Events related to editing armorstands
 public class PlayerEditorManager implements Listener {
-	private ArmorStandEditorPlugin plugin;
-	private HashMap<UUID, PlayerEditor> players;
-	private ASEHolder menuHolder = new ASEHolder(); //Inventory holder that owns the main ase menu inventories for the plugin
-	private ASEHolder equipmentHolder = new ASEHolder(); //Inventory holder that owns the equipment menu
+	private  ArmorStandEditorPlugin plugin;
+	private  HashMap<UUID, PlayerEditor> players;
+	private  ASEHolder menuHolder = new ASEHolder(); //Inventory holder that owns the main ase menu inventories for the plugin
+	private  ASEHolder equipmentHolder = new ASEHolder(); //Inventory holder that owns the equipment menu
 	double coarseAdj;
 	double fineAdj;
 	double coarseMov;
 	double fineMov;
 	private boolean ignoreNextInteract = false;
-	private TickCounter counter;
+	private  TickCounter counter;
 	private ArrayList<ArmorStand> as = null;
 	private ArrayList<ItemFrame> itemF = null;
+	private ArrayList<ItemFrame> itemFrameLookedAt = null;
+
 
 	PlayerEditorManager( ArmorStandEditorPlugin plugin) {
 		this.plugin = plugin;
@@ -406,49 +406,6 @@ public class PlayerEditorManager implements Listener {
 		if (e.getInventory().getHolder() == equipmentHolder) {
 			 PlayerEditor pe = players.get(e.getPlayer().getUniqueId());
 			pe.equipMenu.equipArmorstand();
-		}
-	}
-
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	void checkItemFrameRotate(PlayerInteractEntityEvent event) {
-		final Entity clicked = event.getRightClicked();
-		final ItemFrame itemFrame = (ItemFrame) clicked;
-		final ItemStack itemInFrame = itemFrame.getItem();
-		final Player currentPlayer = event.getPlayer();
-		final Rotation itemFrameRot = itemFrame.getRotation();
-		final PlayerInventory currentInv = currentPlayer.getInventory();
-		final Material itemInHand = currentInv.getItemInMainHand().getType();
-		final boolean isItemFrameVisible = itemFrame.isVisible();
-
-		if (clicked != null && clicked instanceof ItemFrame){ //Only apply the below Logic to Entity ItemFrame
-
-			//Get out once event has been canceled
-			if(isItemFrameVisible){ //ItemFrame is Visible Check - Deal with it being Visible First
-
-				//Firstly, Does ItemFrame contain an Item
-				//If so Keep the Current Rotation and get out ASAP
-				//Get out once event has been canceled
-				if(itemInFrame.getItemMeta() != null){
-					((ItemFrame) clicked).setRotation(itemFrameRot);
-				} else { //No Item
-					//Secondly, If there is no item within and Is the player Holding a Flint
-					//Assume that intention is to add Flint to the ItemFrame
-					if (itemInHand == FLINT) {
-						event.setCancelled(true); //Cancel all Events
-					}
-				}
-			} else{ //ItemFrame Invisible
-				//So we can toggle visiblity later
-				if(itemInFrame.getItemMeta() != null){
-					//Firstly, Does ItemFrame contain an Item
-					//If so Keep the Current Rotation and get out ASAP
-					((ItemFrame) clicked).setRotation(itemFrameRot);
-					event.setCancelled(true); //Cancel all Events
-				}
-			}
-			return;
-		} else{
-			return;
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -416,8 +416,10 @@ public class PlayerEditorManager implements Listener {
 			boolean itemFrameInvis = ((ItemFrame) event.getRightClicked()).isVisible();
 			if(itemFrameInvis) {
 				itemFrameRotated = getFrameTargets(player);
+				if(itemFrameRotated.isEmpty()) return; //Sanity Check
 				if (!itemFrameRotated.isEmpty()) {
 					for (int i = 0; i < itemFrameRotated.size(); i++) {
+						if (!itemFrameRotated.get(i).isVisible()) continue; //Only apply if the ItemFrame is Invisible. Skip if not.
 						if (itemFrameRotated.get(i).getItem().getType() == Material.FLINT) {
 							event.setCancelled(true);
 						}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -431,8 +431,9 @@ public class PlayerEditorManager implements Listener {
 						&& event.getRightClicked().getType().equals(itemF.getType())) {
 					event.setCancelled(true);
 				}
-
 			}
+		} else{ // if if not then we dont do anything and cancel the event.
+			event.setCancelled(false);
 		}
 	}
 

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
@@ -24,7 +24,7 @@ public enum EditMode {
 	HEAD("Head"), BODY("Body"), LEFTARM("LeftArm"), RIGHTARM("RightArm"), LEFTLEG("LeftLeg"), RIGHTLEG("RightLeg"),
 	PLACEMENT("Placement"), DISABLESLOTS("DisableSlots"), ROTATE("Rotate"), EQUIPMENT("Equipment"), RESET("Reset"), ITEMFRAME("ItemFrame"), ITEMFRAMEGLOW("ItemFrameGlow");
 
-	//TODO: Implement ,ITEMFRAMEFIX("FixItemFrame"); in v1.17.1-31
+	//TODO: Implement ,ITEMFRAMEFIX("FixItemFrame"); in v1.17.1-31 or see Wolfst0rm/ArmorStandEditor-Issues#9
 	
 	private String name;
 	

--- a/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/modes/EditMode.java
@@ -23,6 +23,8 @@ public enum EditMode {
 	NONE("None"), INVISIBLE("Invisible"), SHOWARMS("ShowArms"), GRAVITY("Gravity"), BASEPLATE("BasePlate"), SIZE("Size"), COPY("Copy"), PASTE("Paste"),
 	HEAD("Head"), BODY("Body"), LEFTARM("LeftArm"), RIGHTARM("RightArm"), LEFTLEG("LeftLeg"), RIGHTLEG("RightLeg"),
 	PLACEMENT("Placement"), DISABLESLOTS("DisableSlots"), ROTATE("Rotate"), EQUIPMENT("Equipment"), RESET("Reset"), ITEMFRAME("ItemFrame"), ITEMFRAMEGLOW("ItemFrameGlow");
+
+	//TODO: Implement ,ITEMFRAMEFIX("FixItemFrame"); in v1.17.1-31
 	
 	private String name;
 	

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -47,6 +47,8 @@ setgravity:
   false: aus
 nomode: 
   msg: Klicke mit dem Bearbeitungswerkzeug weg vom Ruestungsstaender um den Bearbeitungsmodus auszuwählen!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied: 
   msg: Zustand des Ruestungsstaenders wurde zum Slot <x> kopiert.
 pasted: 

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -50,6 +50,8 @@ setgravity:
   false: off
 nomode:
   msg: Click with the edit tool away from an armorstand to select an editing mode first!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied:
   msg: ArmorStand state copied to slot <x>.
 pasted:

--- a/src/main/resources/lang/es_ES.yml
+++ b/src/main/resources/lang/es_ES.yml
@@ -44,6 +44,8 @@ setgravity:
   false: off
 nomode: 
   msg: Haz click con la herramienta de edicion en un soporte de armaduras para seleccionar un modo de edicion primero
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied: 
   msg: El estado del soporte de armaduras se copio al slot <x>.
 pasted: 

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -46,6 +46,8 @@ setgravity:
   false: désactivée
 nomode: 
   msg: Cliquez d'abord avec cet outil hors d'un valet pour sélectionner un mode d'édition.
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode firs
 copied: 
   msg: État du valet copié dans l'emplacement <x>.
 pasted: 

--- a/src/main/resources/lang/ja_JP.yml
+++ b/src/main/resources/lang/ja_JP.yml
@@ -47,6 +47,8 @@ setgravity:
   false: OFF
 nomode:
   msg: 編集ツールをアーマスタンドから目を逸らした方向でクリックをして、最初の編集モードを選択してください！
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode firs
 copied:
   msg: <x>スロットにアーマースタンドの状態をコピーしました。
 pasted:

--- a/src/main/resources/lang/nl_NL.yml
+++ b/src/main/resources/lang/nl_NL.yml
@@ -47,6 +47,8 @@ setgravity:
   false: uit
 nomode:
   msg: Klik met het aanpas tool weg van een armorstand om een aanpas modus te selecteren!
+nomodeif:
+  msg: Klik met het aanpas tool weg van een itemframe om een aanpas modus te selecteren!
 copied:
   msg: Armorstand status gekopieerd naar slot <x>.
 pasted:

--- a/src/main/resources/lang/pl_PL.yml
+++ b/src/main/resources/lang/pl_PL.yml
@@ -46,6 +46,8 @@ setgravity:
   false: wyłączona
 nomode: 
   msg: Kliknij narzędziem z dala od stojaka na zbroję, aby najpierw wybrać tryb edycji!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied: 
   msg: Skopiowano stoja do slotu <x>.
 pasted: 

--- a/src/main/resources/lang/ro_RO.yml
+++ b/src/main/resources/lang/ro_RO.yml
@@ -45,6 +45,8 @@ setgravity:
   false: oprita
 nomode: 
   msg: Click cu unealta de editare departe de un armorstand pentru a selecta mai intai modul de editare!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied: 
   msg: Starea ArmorStand-ului copiata in slotul <x>.
 pasted: 

--- a/src/main/resources/lang/test_NA.yml
+++ b/src/main/resources/lang/test_NA.yml
@@ -45,6 +45,8 @@ setgravity:
   false: off
 nomode: 
   msg: Click with the edit tool away from an armorstand to select an editing mode first!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied: 
   msg: ArmorStand state copied to slot <x>.
 pasted: 

--- a/src/main/resources/lang/uk_UA.yml
+++ b/src/main/resources/lang/uk_UA.yml
@@ -43,6 +43,8 @@ setgravity:
   false: вимкнена
 nomode:
   msg: Натисни інструментом редагування поза стендом щоб обрати режим!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied:
   msg: Стенд скопійовано в слот <x>.
 pasted:
@@ -153,10 +155,6 @@ rotate:
   msg: Обернути
   description:
     msg: Обертай стенд
-target:
-  msg: Ціль
-  description:
-    msg: СКОРО!
 copy:
   msg: Копія
   description:

--- a/src/main/resources/lang/zh_CN.yml
+++ b/src/main/resources/lang/zh_CN.yml
@@ -48,6 +48,8 @@ setgravity:
   false: 关闭
 nomode:
   msg: 请先点击空气选择设定模式!
+nomodeif:
+  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
 copied:
   msg: 盔甲架装备存档在 <x>.
 pasted:


### PR DESCRIPTION
Deals with the handling of Invisible ItemFrames and rotating. 

We check:

If the RightClicked entity is an ItemFrame
If ItemFrame is Invisible
-If it is not - We don't do anything, we don't cancel the event.
If Invisible, we first check if the player is holding flint
- if not - don't cancel the event
- Otherwise, check if they are right-clicking an itemframe and cancel the event

Fixes Wolfst0rm/ArmorStandEditor-Issues#3