### PR TITLE
[CORE] 1.18 Update

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,12 +13,12 @@ jobs:
       - name: Checkout ArmorStandEditor Repository
         uses: actions/checkout@v2
 
-      # 2. Setup Java 16 JDK
-      - name: Set up JDK 16 Environment
+      # 2. Setup Java 17 JDK
+      - name: Set up JDK 17 Environment
         uses: actions/setup-java@v2
         with:
-          java-version: '16'
-          distribution: 'adopt'
+          java-version: '17' # move this over to 17 when Github Actions Supports it
+          distribution: 'zulu'
 
       # 3. Setup local Maven package cache to speed up building
       - name: Cache SonarCloud packages

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.17-30</version>
+    <version>1.18-pre5-31</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <version>1.18-pre5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-rc3-R0.1-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--- Towny -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <!-- Towny -->
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -29,6 +34,13 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.18-rc3-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--- Towny -->
+        <dependency>
+            <groupId>com.github.TownyAdvanced</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.97.3.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -40,8 +52,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>11</source>
+                    <target>11</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.97.3.0</version>
+            <version>0.96.7.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.18-prc3-31</version>
+    <version>1.18-31</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <groupId>io.github.rypofalem.armorstandeditor</groupId>
     <artifactId>armorstandeditor</artifactId>
     <packaging>jar</packaging>
-    <version>1.18-pre5-31</version>
+    <version>1.18-prc3-31</version>
     <name>armorstandeditor</name>
     <url>http://maven.apache.org</url>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <sonar.organization>wolfst0rm</sonar.organization>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-pre5-R0.1-SNAPSHOT</version>
+            <version>1.18-rc3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -133,6 +133,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		}
 
 		//Also Warn People to Update if using nmsVersion lower than latest
+		//TODO: Add 1.17 to Non Latest ONCE 1.18 Spigot is Available
 		if (    nmsVersion.startsWith("v1_13") ||
 				nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||
@@ -351,5 +352,3 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		return iconKey;
 	}
 }
-//todo:
-//Access to the "Marker" switch (so you can make the hitbox super small)

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -54,6 +54,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 	private String nmsVersion = null;
 	private String nmsVersionNotLatest = null;
 	PluginDescriptionFile pdfFile = this.getDescription();
+	final String SEPERATOR = "================================";
 
 	public PlayerEditorManager editorManager;
 
@@ -121,32 +122,36 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		}
 
 		//Minimum Version Check - No Lower than 1.13-API. Will be tuned out in the future
+		//TODO: Move V1_13 to Unsupported List, as we do not want to keep versions supported longer than necessary
+		//ETA on V1_13 Support being Dropped - Jan 2022!
 		if (    nmsVersion.startsWith("v1_8")  ||
 				nmsVersion.startsWith("v1_9")  ||
 				nmsVersion.startsWith("v1_10") ||
 				nmsVersion.startsWith("v1_11") ||
 				nmsVersion.startsWith("v1_12")){
 			getLogger().warning("Minecraft Version: " + nmsVersion + " is not supported. Loading Plugin Failed.");
-			getLogger().info("================================");
+			getLogger().info(SEPERATOR);
 			getServer().getPluginManager().disablePlugin(this);
 			return;
 		}
 
 		//Also Warn People to Update if using nmsVersion lower than latest
-		//TODO: Add 1.17 to Non Latest ONCE 1.18 Spigot is Available
+		//TODO: Uncomment things
 		if (    nmsVersion.startsWith("v1_13") ||
 				nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||
-				nmsVersion.startsWith("v1_16") ){/*||
-			    nmsVersion.startsWith("v1_17")){
-			    Uncomment this after V1_18 is released (So not RC or Pre)*/
+				nmsVersion.startsWith("v1_16") ){
 			getLogger().warning("Minecraft Version: " + nmsVersion + " is supported, but not latest.");
 			getLogger().warning("ArmorStandEditor will still work, but please update to the latest Version of " + nmsVersionNotLatest + ". Loading continuing.");
+		} else if (nmsVersion.startsWith("V1_18")){ //Do Not Report this!
+			getLogger().warning("Minecraft Version: " + nmsVersion + "currently has preliminary support.");
+			getLogger().warning("Please note: Things are confirmed working and we will update to support 1.18 ASAP!");
+			getLogger().warning("Thanks for understanding. King Regards, Wolfstorm!");
 		} else {
 			getLogger().info("Minecraft Version: " + nmsVersion + " is supported. Loading continuing.");
 		}
 		getServer().getPluginManager().enablePlugin(this);
-		getLogger().info("================================");
+		getLogger().info(SEPERATOR);
 
 		//saveResource doesn't accept File.separator on windows, need to hardcode unix separator "/" instead
 		updateConfig("", "config.yml");
@@ -173,7 +178,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 			editTool = Material.getMaterial(toolType); //Ignore Warning
 		} else {
 			 getLogger().severe("Unable to get Tool for Use with Plugin. Unable to continue!");
-			 getLogger().info("================================");
+			 getLogger().info(SEPERATOR);
 			 getServer().getPluginManager().disablePlugin(this);
 			 return;
 		}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -123,7 +123,6 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
 		//Minimum Version Check - No Lower than 1.13-API. Will be tuned out in the future
 		//TODO: Move V1_13 to Unsupported List, as we do not want to keep versions supported longer than necessary
-		//ETA on V1_13 Support being Dropped - Jan 2022!
 		if (    nmsVersion.startsWith("v1_8")  ||
 				nmsVersion.startsWith("v1_9")  ||
 				nmsVersion.startsWith("v1_10") ||
@@ -140,13 +139,10 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		if (    nmsVersion.startsWith("v1_13") ||
 				nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||
-				nmsVersion.startsWith("v1_16") ){
+				nmsVersion.startsWith("v1_16") ||
+				nmsVersion.startsWith("v1_17")){
 			getLogger().warning("Minecraft Version: " + nmsVersion + " is supported, but not latest.");
 			getLogger().warning("ArmorStandEditor will still work, but please update to the latest Version of " + nmsVersionNotLatest + ". Loading continuing.");
-		} else if (nmsVersion.startsWith("V1_18")){ //Do Not Report this!
-			getLogger().warning("Minecraft Version: " + nmsVersion + "currently has preliminary support.");
-			getLogger().warning("Please note: Things are confirmed working and we will update to support 1.18 ASAP!");
-			getLogger().warning("Thanks for understanding. King Regards, Wolfstorm!");
 		} else {
 			getLogger().info("Minecraft Version: " + nmsVersion + " is supported. Loading continuing.");
 		}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -137,7 +137,9 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		if (    nmsVersion.startsWith("v1_13") ||
 				nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||
-				nmsVersion.startsWith("v1_16")){
+				nmsVersion.startsWith("v1_16") ){/*||
+			    nmsVersion.startsWith("v1_17")){
+			    Uncomment this after V1_18 is released (So not RC or Pre)*/
 			getLogger().warning("Minecraft Version: " + nmsVersion + " is supported, but not latest.");
 			getLogger().warning("ArmorStandEditor will still work, but please update to the latest Version of " + nmsVersionNotLatest + ". Loading continuing.");
 		} else {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -322,37 +322,21 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 			assert languageUsed != null;
 			if(languageUsed.startsWith("nl")){
 				map.put("Dutch", entry);
-			}
-
-			if(languageUsed.startsWith("de")){
+			} else if(languageUsed.startsWith("de")){
 				map.put("German", entry);
-			}
-
-			if(languageUsed.startsWith("es")){
+			} else if(languageUsed.startsWith("es")){
 				map.put("Spanish", entry);
-			}
-
-			if(languageUsed.startsWith("fr")){
+			} else if(languageUsed.startsWith("fr")){
 				map.put("French", entry);
-			}
-
-			if(languageUsed.startsWith("ja")){
+			} else if(languageUsed.startsWith("ja")){
 				map.put("Japanese", entry);
-			}
-
-			if(languageUsed.startsWith("pl")){
+			} else if(languageUsed.startsWith("pl")){
 				map.put("Polish", entry);
-			}
-
-			if(languageUsed.startsWith("ro")){
+			} else if(languageUsed.startsWith("ro")){
 				map.put("Romanian", entry);
-			}
-
-			if(languageUsed.startsWith("uk")){
+			} else if(languageUsed.startsWith("uk")){
 				map.put("Ukrainian", entry);
-			}
-
-			if(languageUsed.startsWith("zh")){
+			} else if(languageUsed.startsWith("zh")){
 				map.put("Chinese", entry);
 			} else{
 				map.put("Other", entry);

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -54,7 +54,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 	private String nmsVersion = null;
 	private String nmsVersionNotLatest = null;
 	PluginDescriptionFile pdfFile = this.getDescription();
-	final String SEPERATOR = "================================";
+	final static String SEPERATOR = "================================";
 
 	public PlayerEditorManager editorManager;
 
@@ -135,7 +135,6 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		}
 
 		//Also Warn People to Update if using nmsVersion lower than latest
-		//TODO: Uncomment things
 		if (    nmsVersion.startsWith("v1_13") ||
 				nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -122,12 +122,13 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		}
 
 		//Minimum Version Check - No Lower than 1.13-API. Will be tuned out in the future
-		//TODO: Move V1_13 to Unsupported List, as we do not want to keep versions supported longer than necessary
 		if (    nmsVersion.startsWith("v1_8")  ||
 				nmsVersion.startsWith("v1_9")  ||
 				nmsVersion.startsWith("v1_10") ||
 				nmsVersion.startsWith("v1_11") ||
-				nmsVersion.startsWith("v1_12")){
+				nmsVersion.startsWith("v1_12") ||
+				nmsVersion.startsWith("v1_13")
+				){
 			getLogger().warning("Minecraft Version: " + nmsVersion + " is not supported. Loading Plugin Failed.");
 			getLogger().info(SEPERATOR);
 			getServer().getPluginManager().disablePlugin(this);
@@ -135,8 +136,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 		}
 
 		//Also Warn People to Update if using nmsVersion lower than latest
-		if (    nmsVersion.startsWith("v1_13") ||
-				nmsVersion.startsWith("v1_14") ||
+		if (    nmsVersion.startsWith("v1_14") ||
 				nmsVersion.startsWith("v1_15") ||
 				nmsVersion.startsWith("v1_16") ||
 				nmsVersion.startsWith("v1_17")){

--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -322,21 +322,37 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 			assert languageUsed != null;
 			if(languageUsed.startsWith("nl")){
 				map.put("Dutch", entry);
-			} else if(languageUsed.startsWith("de")){
+			}
+
+			if(languageUsed.startsWith("de")){
 				map.put("German", entry);
-			} else if(languageUsed.startsWith("es")){
+			}
+
+			if(languageUsed.startsWith("es")){
 				map.put("Spanish", entry);
-			} else if(languageUsed.startsWith("fr")){
+			}
+
+			if(languageUsed.startsWith("fr")){
 				map.put("French", entry);
-			} else if(languageUsed.startsWith("ja")){
+			}
+
+			if(languageUsed.startsWith("ja")){
 				map.put("Japanese", entry);
-			} else if(languageUsed.startsWith("pl")){
+			}
+
+			if(languageUsed.startsWith("pl")){
 				map.put("Polish", entry);
-			} else if(languageUsed.startsWith("ro")){
+			}
+
+			if(languageUsed.startsWith("ro")){
 				map.put("Romanian", entry);
-			} else if(languageUsed.startsWith("uk")){
+			}
+
+			if(languageUsed.startsWith("uk")){
 				map.put("Ukrainian", entry);
-			} else if(languageUsed.startsWith("zh")){
+			}
+
+			if(languageUsed.startsWith("zh")){
 				map.put("Chinese", entry);
 			} else{
 				map.put("Other", entry);

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -43,6 +43,7 @@ public class CommandEx implements CommandExecutor {
 	final String LISTSLOT = ChatColor.YELLOW + "/ase slot <1-9>";
 	final String RELOAD = ChatColor.YELLOW + "/ase reload";
 	final String HELP = ChatColor.YELLOW + "/ase help";
+	final String VERSION = ChatColor.YELLOW + "/ase version";
 
 	/*//Reload Stuff
 	Material editTool;
@@ -93,15 +94,24 @@ public class CommandEx implements CommandExecutor {
 			case "help":
 			case "?": commandHelp(player);
 				break;
+			case "version": commandVersion(player);
+				break;
 			default:
 				sender.sendMessage(LISTMODE);
 				sender.sendMessage(LISTAXIS);
 				sender.sendMessage(LISTSLOT);
 				sender.sendMessage(LISTADJUSTMENT);
-				sender.sendMessage(RELOAD);
+				//sender.sendMessage(RELOAD);
+				sender.sendMessage(VERSION);
 				sender.sendMessage(HELP);
 		}
 		return true;
+	}
+
+	private void commandVersion(Player player) {
+		if (!(checkPermission(player, "basic", true))) return;
+		String verString = plugin.pdfFile.getVersion();
+		player.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
 	}
 
 	//Reload Command Now Expanded Upon.

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -78,7 +78,6 @@ public class CommandEx implements CommandExecutor {
 				sender.sendMessage(LISTAXIS);
 				sender.sendMessage(LISTSLOT);
 				sender.sendMessage(LISTADJUSTMENT);
-				//sender.sendMessage(RELOAD);
 				sender.sendMessage(VERSION);
 				sender.sendMessage(HELP);
 		}

--- a/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/CommandEx.java
@@ -23,17 +23,11 @@ import io.github.rypofalem.armorstandeditor.modes.AdjustmentMode;
 import io.github.rypofalem.armorstandeditor.modes.Axis;
 import io.github.rypofalem.armorstandeditor.modes.EditMode;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.PluginDescriptionFile;
-
-import java.time.DateTimeException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 public class CommandEx implements CommandExecutor {
 	ArmorStandEditorPlugin plugin;
@@ -41,23 +35,8 @@ public class CommandEx implements CommandExecutor {
 	final String LISTAXIS = ChatColor.YELLOW + "/ase axis <" + Util.getEnumList(Axis.class) + ">";
 	final String LISTADJUSTMENT = ChatColor.YELLOW + "/ase adj <" + Util.getEnumList(AdjustmentMode.class) + ">";
 	final String LISTSLOT = ChatColor.YELLOW + "/ase slot <1-9>";
-	final String RELOAD = ChatColor.YELLOW + "/ase reload";
 	final String HELP = ChatColor.YELLOW + "/ase help";
 	final String VERSION = ChatColor.YELLOW + "/ase version";
-
-	/*//Reload Stuff
-	Material editTool;
-	boolean requireToolData = false;
-	boolean sendToActionBar = true;
-	int editToolData = Integer.MIN_VALUE;
-	boolean requireToolLore = false;
-	String editToolLore = null;
-	boolean debug = false; //weather or not to broadcast messages via print(String message)
-	double coarseRot;
-	double fineRot;
-	boolean glowItemFrames;
-	String toolType = null;
-	LocalDateTime now = LocalDateTime.now();*/
 
 	public CommandEx( ArmorStandEditorPlugin armorStandEditorPlugin) {
 		this.plugin = armorStandEditorPlugin;
@@ -89,8 +68,6 @@ public class CommandEx implements CommandExecutor {
 				break;
 			case "slot": commandSlot(player, args);
 				break;
-			/*case "reload": commandReload(player, args);
-			    break;*/
 			case "help":
 			case "?": commandHelp(player);
 				break;
@@ -113,56 +90,6 @@ public class CommandEx implements CommandExecutor {
 		String verString = plugin.pdfFile.getVersion();
 		player.sendMessage(ChatColor.YELLOW + "[ArmorStandEditor] Version: " + verString);
 	}
-
-	//Reload Command Now Expanded Upon.
-/*	private void commandReload(Player player, String[] args){
-		if(!(checkPermission(player, "reload", true))) return; //Basic sanity Check for Reload Permission!
-		if(args.length < 1 ){
-			// Check the Length of Args. If > 0 then pass noReload
-			player.sendMessage(plugin.getLang().getMessage("noreloadcom", "warn"));
-			player.sendMessage(RELOAD);
-		} else {
-			// else if = 0 then get do one final check on the permission
-
-			DateTimeFormatter format = DateTimeFormatter.ofPattern("EEEE, dd MMMM yyyy HH:mm:ss");
-
-			if (checkPermission(player, "reload", true)) {
-				// if permission true then run Reload and Load all the Values, Message that it has been reloaded successfully. Log to Console, Reload on DateTime by Player
-				this.loadConfig();
-				plugin.saveConfig();
-				plugin.reloadConfig();
-				player.sendMessage(plugin.getLang().getMessage("reloaded", "info"));
-				plugin.log("Configuration File has reloaded on "+ now.format(format) +  " by " + player.getName() + "");
-			}
-		}
-	}
-
-	//Potential to add Validation In Here SOMEHOW? TO Validate that the file is good in that regard.
-	private void loadConfig(){
-		//Get all the Changes - Not accepting changes without a FULL RELOAD
-		coarseRot = plugin.getConfig().getDouble("coarse");
-		fineRot = plugin.getConfig().getDouble("fine");
-
-		//Set Tool to be used in game
-		toolType = plugin.getConfig().getString("tool");
-		if (toolType != null) {
-			editTool = Material.getMaterial(toolType); //Ignore Warning
-		} else {
-			plugin.getLogger().severe("Unable to get Tool for Use with Plugin. Unable to continue!");
-			plugin.getServer().getPluginManager().disablePlugin(plugin);
-			return;
-		}
-
-		requireToolData = plugin.getConfig().getBoolean("requireToolData", false);
-		if(requireToolData) editToolData = plugin.getConfig().getInt("toolData", Integer.MIN_VALUE);
-		requireToolLore = plugin.getConfig().getBoolean("requireToolLore", false);
-		if(requireToolLore) editToolLore= plugin.getConfig().getString("toolLore", null);
-
-		debug = plugin.getConfig().getBoolean("debug", true);
-		sendToActionBar = plugin.getConfig().getBoolean("sendMessagesToActionBar", true);
-		glowItemFrames = plugin.getConfig().getBoolean("glowingItemFrame", true);
-
-	}*/
 
 
 	private void commandSlot(Player player, String[] args) {

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -113,9 +113,13 @@ public class PlayerEditor {
 
 	public void editArmorStand(ArmorStand armorStand) {
 		if (!getPlayer().hasPermission("asedit.basic")) return;
+
 		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15 - Towny Support not working!
-		if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
-		if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation(), Material.ARMOR_STAND)) return;
+		if (plugin.getServer().getPluginManager().getPlugin("Towny") != null) {
+			if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
+			if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation().getBlock().getLocation(), Material.ARMOR_STAND)) return;
+		}
+
 		armorStand = attemptTarget(armorStand);
 		switch (eMode) {
 			case LEFTARM:
@@ -210,8 +214,10 @@ public class PlayerEditor {
 	public void reverseEditArmorStand(ArmorStand armorStand) {
 		if (!getPlayer().hasPermission("asedit.basic")) return;
 		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15 - Towny Support not working!
-		if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
-		if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation().getBlock().getLocation(), Material.ARMOR_STAND)) return;
+		if (plugin.getServer().getPluginManager().getPlugin("Towny") != null) {
+			if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
+			if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation().getBlock().getLocation(), Material.ARMOR_STAND)) return;
+		}
 		armorStand = attemptTarget(armorStand);
 		switch (eMode) {
 			case LEFTARM:

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -114,7 +114,7 @@ public class PlayerEditor {
 	public void editArmorStand(ArmorStand armorStand) {
 		if (!getPlayer().hasPermission("asedit.basic")) return;
 
-		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15 - Towny Support not working!
+		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15
 		if (plugin.getServer().getPluginManager().getPlugin("Towny") != null) {
 			if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
 			if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation().getBlock().getLocation(), Material.ARMOR_STAND)) return;

--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditor.java
@@ -19,6 +19,8 @@
 
 package io.github.rypofalem.armorstandeditor;
 
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.event.executors.TownyActionEventExecutor;
 import io.github.rypofalem.armorstandeditor.menu.EquipmentMenu;
 import io.github.rypofalem.armorstandeditor.menu.Menu;
 import io.github.rypofalem.armorstandeditor.modes.AdjustmentMode;
@@ -111,6 +113,9 @@ public class PlayerEditor {
 
 	public void editArmorStand(ArmorStand armorStand) {
 		if (!getPlayer().hasPermission("asedit.basic")) return;
+		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15 - Towny Support not working!
+		if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
+		if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation(), Material.ARMOR_STAND)) return;
 		armorStand = attemptTarget(armorStand);
 		switch (eMode) {
 			case LEFTARM:
@@ -204,6 +209,9 @@ public class PlayerEditor {
 
 	public void reverseEditArmorStand(ArmorStand armorStand) {
 		if (!getPlayer().hasPermission("asedit.basic")) return;
+		//FIX for https://github.com/Wolfst0rm/ArmorStandEditor-Issues/issues/15 - Towny Support not working!
+		if (TownyAPI.getInstance().isWilderness(getPlayer().getLocation())) return;
+		if (!TownyActionEventExecutor.canDestroy(getPlayer(), getPlayer().getLocation().getBlock().getLocation(), Material.ARMOR_STAND)) return;
 		armorStand = attemptTarget(armorStand);
 		switch (eMode) {
 			case LEFTARM:

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -10,10 +10,10 @@ warn: c
 menutitle: 8
 
 #info
-setmode: 
+setmode:
   msg: Setze Modus zu <x>.
   head: Kopf Position
-  body: Koerper Position
+  body: Körper Position
   leftleg: Linkes Bein Position
   rightleg: Rechtes Bein Position
   leftarm: Linker Arm Position
@@ -25,193 +25,193 @@ setmode:
   disableslots: Deaktivierte Slots umschalten
   gravity: Erdanziehungskraft umschalten
   baseplate: Bodenplatte umschalten
-  placement: Plazierung
+  placement: Platzierung
   rotate: Drehen
   copy: Kopieren
   paste: Einfügen
   reset: Reset Pose
-setaxis: 
-  msg: Setze Axen zu <x>.
+setaxis:
+  msg: Setze Achsen zu <x>.
   x: X
   y: Y
   z: Z
-setslot: 
-  msg: Setze Kopier Slot zu <x>.
+setslot:
+  msg: Setze Kopier-Slot zu <x>.
 setadj:
   msg: Setze Anpassung zu <x>.
   coarse: Grob
   fine: Fein
-setgravity: 
+setgravity:
   msg: Erdanziehungskraft <x>.
   true: an
   false: aus
-nomode: 
-  msg: Klicke mit dem Bearbeitungswerkzeug weg vom Ruestungsstaender um den Bearbeitungsmodus auszuwählen!
+nomode:
+  msg: Klicke mit dem Bearbeitungswerkzeug weg vom Rüstungsständer um den Bearbeitungsmodus auszuwählen!
 nomodeif:
-  msg: Click with the Edit Tool away from the ItemFrame to select a mode first!
-copied: 
-  msg: Zustand des Ruestungsstaenders wurde zum Slot <x> kopiert.
-pasted: 
-  msg: Zustand des Ruestungsstaenders wurde vom Slot <x> eingefuegt.
+  msg: Um zuerst einem Modus auszuwählen, klicke mit dem Bearbeitungswerkzeug neben einem ItemFrame!
+copied:
+  msg: Zustand des Rüstungsständers wurde zum Slot <x> kopiert.
+pasted:
+  msg: Zustand des Rüstungsständers wurde vom Slot <x> eingefügt.
 target:
-  msg: Ziel Ruestungsstaender wurde gesperrt.
+  msg: Ziel Rüstungsständer wurde gesperrt.
 notarget:
-  msg: Ziel Ruestungsstaender wurde entsperrt.
+  msg: Ziel Rüstungsständer wurde entsperrt.
 frametarget:
-  msg: Itemframe target locked
+  msg: Itemframe Ziel gesperrt.
 noframetarget:
-  msg: Itemframe target unlocked.
+  msg: Itemframe Ziel entsperrt.
 doubletarget:
-  msg: Please look at either an ArmorStand or an ItemFrame, not both!
+  msg: Bitte schaue entweder auf einen Rüstungsständer oder einem ItemFrame, nicht beides!
 help:
   msg: "1. Halte das Bearbeitungswerkzeug(<x>) in deiner Haupthand.
 
-      2. Links oder Rechsklicke entfernt von einem Ruestungsstaender um das Menue zu oeffnen.
+      2. Links oder Rechsklicke entfernt von einem Rüstungsständer um das Menü zu öffnen.
 
-      3. Waehle zwischen den beschrifteten Menue Optionen.
+      3. Wähle zwischen den beschrifteten Menü Optionen.
 
-      4. Linksklicke den Ruestungsstaender mit dem Bearbeitungswerzeug um die Aenderungen zu uebernehmen.
+      4. Linksklicke den Rüstungsständer mit dem Bearbeitungswerkzeug um die Änderungen zu übernehmen.
 
-      5. Rechtsklicke um die Aenderungen zu verwerfen!"
+      5. Rechtsklicke um die Änderungen zu verwerfen!"
 helptips:
   msg: "Tipps:
 
-  1. Druecke die \"Gegenstand in den Haenden wechseln\" Taste (Standard: F) waehrend du das Bearbeitungswerkzeug haeltst um einen speziellen Ruestungsstaender auszuwaehlen falls mehrere in der Naehe sind.
+  1. Drücke die \"Gegenstand in den Händen wechseln\" Taste (Standard: F) während du das Bearbeitungswerkzeug hältst um einen speziellen Rüstungsständer auszuwählen falls mehrere in der Nähe sind.
 
-  2. Du kannst Nametags zu Ruestungsstaender hinzufuegen. Du kannst das \"&\" Symbol für Farben benutzen.
+  2. Du kannst Nametags zu Rüstungsständer hinzufügen. Du kannst das \"&\" Symbol für Farben benutzen.
 
-  3. Du kannst sneaken und das Scrollrad drehen waehrend du das Bearbeitungswerkzeug haelst um die Axen zu waechseln ohne das Menue zu oeffnen."
+  3. Du kannst sneaken und das Scrollrad drehen während du das Bearbeitungswerkzeug hältst um die Achsen zu wechseln ohne das Menü zu öffnen."
 helpurl:
   msg: "Weitere Infos: https://github.com/RypoFalem/ArmorStandEditor/wiki"
 
 #warn
 cantedit:
-  msg: Entschuldigung, du kannst hier keine Ruestungsstaender bearbeiten!
-noperm: 
+  msg: Entschuldigung, du kannst hier keine Rüstungsständer bearbeiten!
+noperm:
   msg: Du hast keine Erlaubnis diesen Befehl zu nutzen!
-noslotnumcom: 
+noslotnumcom:
   msg: Du musst eine Slotnummer angeben!
 noadjcom:
-  msg: Du musst Grob oder Fein auswaehlen!
+  msg: Du musst Grob oder Fein auswählen!
 noaxiscom:
-  msg: Du musst eine Axe auswaehlen!
+  msg: Du musst eine Achse auswählen!
 nomodecom:
-  msg: Du musst einen Modus auswaehlen!
+  msg: Du musst einen Modus auswählen!
 
 #menutitle
 mainmenutitle:
-  msg: Ruestungsstaender Editor Menue
+  msg: Rüstungsständer Editor Menü
 equiptitle:
-  msg: Ruestungsstaender Ausruestung
+  msg: Rüstungsständer Ausrüstung
 
 #icons
 xaxis:
-  msg: X Axe
-  description: 
-    msg: Rotiere Koerperteile entlang der X Axe
-yaxis: 
-  msg: Y Axe
-  description: 
-    msg: Rotiere Koerperteile entlang der Y Axe
-zaxis: 
-  msg: Z Axe
-  description: 
-    msg: Rotiere Koerperteile entlang der Z Axe
-coarseadj: 
+  msg: X Achse
+  description:
+    msg: Rotiere Körperteile entlang der X Achse
+yaxis:
+  msg: Y Achse
+  description:
+    msg: Rotiere Körperteile entlang der Y Achse
+zaxis:
+  msg: Z Achse
+  description:
+    msg: Rotiere Körperteile entlang der Z Achse
+coarseadj:
   msg: Grobe Anpassungen
-  description: 
+  description:
     msg: Mache Grobe Anpassungen
-fineadj: 
+fineadj:
   msg: Feine Anpassungen
-  description: 
+  description:
     msg: Mache Feine Anpassungen
-head: 
+head:
   msg: Kopf Position
-  description: 
+  description:
     msg: Rotiere den Kopf
-body: 
-  msg: Koerper Position
-  description: 
+body:
+  msg: Körper Position
+  description:
     msg: Rotiere den Körper
-leftleg: 
+leftleg:
   msg: Linkes Bein Position
-  description: 
+  description:
     msg: Rotiere das linke Bein
-rightleg: 
+rightleg:
   msg: Rechtes Bein Position
-  description: 
+  description:
     msg: Rotiere das rechte Bein
-leftarm: 
+leftarm:
   msg: Linker Arm Position
-  description: 
+  description:
     msg: Rotiere den linken Arm
-rightarm: 
+rightarm:
   msg: Rechter Arm Position
-  description: 
+  description:
     msg: Rotiere den rechten Arm
-equipment: 
-  msg: Ausruestung
-  description: 
-    msg: Bearbeite Ausruestung
-showarms: 
+equipment:
+  msg: Ausrüstung
+  description:
+    msg: Bearbeite Ausrüstung
+showarms:
   msg: Zeige Arme
-  description: 
+  description:
     msg: Aktiviere oder Deaktiviere die Arme
-invisible: 
+invisible:
   msg: Sichtbarkeit
-  description: 
+  description:
     msg: Mach es Sichtbar oder Unsichtbar
-size: 
+size:
   msg: Größe
-  description: 
+  description:
     msg: Mach es Groß oder Klein
-disableslots: 
+disableslots:
   msg: Deaktiviere Slots
-  description: 
-    msg: Aktiviere und Deaktiviere die Ausruestungssperre
-gravity: 
+  description:
+    msg: Aktiviere und Deaktiviere die Ausrüstungssperre
+gravity:
   msg: Erdanziehungskraft
-  description: 
+  description:
     msg: Schalte die Erdanziehungskraft an oder aus
-baseplate: 
+baseplate:
   msg: Bodenplatte
-  description: 
+  description:
     msg: Schalte die Bodenplatte an oder aus
-placement: 
+placement:
   msg: Plazierung
-  description: 
-    msg: Verschiebe den kompletten Ruestungsstaender
-rotate: 
+  description:
+    msg: Verschiebe den kompletten Rüstungsständer
+rotate:
   msg: Rotiere
   description:
-    msg: Rotiere den kompletten Ruestungsstaender
-copy: 
+    msg: Rotiere den kompletten Rüstungsständer
+copy:
   msg: Kopieren
   description:
-    msg: Kopiere die Ruestungsstaender Einstellungen
-paste: 
+    msg: Kopiere die Rüstungsständer Einstellungen
+paste:
   msg: Einfügen
-  description:  
-    msg: Füge den Ruestungsstaender ein
-copyslot: 
+  description:
+    msg: Füge den Rüstungsständer ein
+copyslot:
   msg: Kopiere Slot <x>
   description:
-    msg: Waehle einen Slot um die Einstellungen zu speichern
+    msg: Wähle einen Slot um die Einstellungen zu speichern
 reset:
-  msg: Pose zuruecksetzen
+  msg: Pose zurücksetzen
   description:
-    msg: Setze die Pose zurueck
+    msg: Setze die Pose zurück
 helpgui:
   msg: Hilfe!
   description:
     msg: Klicke hier um Hilfe zu erhalten!
 
 #icons (equipment menu)
-disabled: 
+disabled:
   msg: Deaktiviert
-equipslot: 
+equipslot:
   msg: <x> Slot
-  description: 
+  description:
     msg: Ziehe deine <x> in den Slot unterhalb
     helm: Helm
     chest: Brustplatte

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.17-30
+version: 1.18-pre5-30
 api-version: "1.13"
 website: rypofalem.github.io
 author: Wolfstorm

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.18-pre5-30
+version: 1.18-rc3-31
 api-version: "1.13"
 website: rypofalem.github.io
 author: Wolfstorm
@@ -27,7 +27,3 @@ permissions:
     asedit.disableslots:
       description: Allows locking and unlocking the contents of an ArmorStand. When locked, armor and equipement can not be added or removed without unlocking it first.
       default: true
-#   NOT CURRENTLY IN USE! Coming in a future update
-#    asedit.reload:
-#      description: Reload Configs for ArmorStandEditor
-#      default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ArmorStandEditor
 main: io.github.rypofalem.armorstandeditor.ArmorStandEditorPlugin
-version: 1.18-rc3-31
+version: 1.18-31
 api-version: "1.13"
 website: rypofalem.github.io
 author: Wolfstorm

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ website: rypofalem.github.io
 author: Wolfstorm
 authors: [Wolfstorm, Marfjeh, rypofalem, sekwah41, Sikatsu1997, Cool_boy, sumdream, Amaury Carrade, nicuch, kotarobo, prettydude, Jumpy91, Niasio, Patbox, Puremin0rez, Prof-Bloodstone]
 description: Allows players to edit data of armorstands without any commands.
+softdepend: [Towny]
 commands:
   ase:
     description: Changes the function of the armorstand edit tool.


### PR DESCRIPTION
Enables support for Caves and Cliffs Part 2 slated to come out November 30th.

**Done:**
- Currently supports 1.18-pre5-30, perfectly fine.
- Added new Language Support file for German (thank you Sulort)
- Support for 1.17 Versions moved to Supported but please update to latest.
- Code Review Fixes from Sonar and so on
- Towny Support

Ongoing PR until after 1.18 releases and after I move. Wanted to add preliminary support for now :) 

Disclaimers:
> Remember that this is a pre-release version. Significant changes may occur before release and upgrades to other pre-releases should not be expected.

> Please note that we do not consider pre-releases a stable version. In particular there will be no attempt at compatibility between 1.18-pre5 and 1.18. That is to say the existence of 1.18-pre5 will be ignored when 1.18 releases. You have been warned.

Feel free to test this out yourself and report any issues to the master 1.18 Issues Tracker.